### PR TITLE
Fixing template azuredeploy.json

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -29,7 +29,7 @@
         "networkSecurityGroups_quote_nsg_name": {
             "defaultValue": "quote-nsg",
             "type": "string"
-        },
+        }
     },
     "variables": {},
     "resources": [


### PR DESCRIPTION
Current `azuredeploy.json` doesn't working, because of the character `,` ending the list of `parameters`:
```PowerShell
PS C:\Users\UserName> az group deployment validate --resource-group DeployanNtierarchitecture --template-uri  "https://raw.githubusercontent.com/MicrosoftDocs/mslearn
-n-tier-architecture/master/Deployment/azuredeploy.json"
Expecting property name enclosed in double quotes: line 33 column 5 (char 1035)
```

After changes, template is working fine:
```PowerShell
PS C:\Users\UserName> az group deployment validate --resource-group DeployanNtierarchitecture --template-uri  "https://raw.githubusercontent.com/bpelikan/mslearn-n-ti
er-architecture/template-fix/Deployment/azuredeploy.json"
{
  "error": null,
 ...
```